### PR TITLE
maven 3.3.3 is no longer available from apache.org

### DIFF
--- a/spring-boot/springboot-sti/Dockerfile
+++ b/spring-boot/springboot-sti/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Jorge Morales <jmorales@redhat.com>
 # Install build tools on top of base image
 # Java jdk 8, Maven 3.3, Gradle 2.6
 ENV GRADLE_VERSION 2.6
-ENV MAVEN_VERSION 3.3.3
+ENV MAVEN_VERSION 3.3.9
 
 RUN yum install -y --enablerepo=centosplus \
     tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel && \


### PR DESCRIPTION
3.3.9 is the currently available version.
